### PR TITLE
Improve faq loading

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: gunicorn -w 6 -k gevent --worker-connections 512 --max-requests 1000 pskb_website:app
-worker: celery worker --app=pskb_website.tasks.celery
+web: newrelic-admin run-program gunicorn -w 6 -k gevent --worker-connections 512 --max-requests 1000 pskb_website:app
+worker: newrelic-admin run-program celery worker --app=pskb_website.tasks.celery

--- a/docs/merging_changes.rst
+++ b/docs/merging_changes.rst
@@ -71,3 +71,33 @@ Integrating some changes from branch
     - Run `git push origin :<branch_name>` to remove the branch from github.com.  You can also do this via github.com by browsing the branches again and clicking the trash can icon next to the branch.
 7. Push the changes to github.com
     - Run `git push origin master`
+
+-----------------------------------
+Easier visualizing of complex diffs
+-----------------------------------
+
+Often times prose is harder to diff than code because the length of a line can
+be very long.  For example, it's common for an entire paragraph to be a single
+line in prose whereas software is usually broken up into small lines with hard
+linebreaks.
+
+This means a diff for prose could show a large change when in reality on a few
+words were changed.  The diff tools on github.com and `git` can help here if
+you know the right options to use.
+
+Github.com
+----------
+
+Github.com defaults to 'source diff view, but you can change this in the
+top-right hand corner of any commit page.  Try clicking the 'rich diff' icon
+next to the 'view' button for a different view.
+
+Git
+---
+
+First, try using `git log --word-diff=color -p` to see diffs.  Another trick is
+to find the two adjacent commits on a file and do something like the
+`git diff --word-diff=color d98909743b32df2f44e835162f50e5b6b7f92c1c..8bc2725698b84d95014b0124c141a08b1946718 in-review/ruby-ruby-on-rails/handling-file-upload-using-ruby-on-rails-5-api/article.md`
+
+You can get the two adjacent commits for a file by running `git log --follow
+<path_to_file>`.

--- a/pskb_website/api.py
+++ b/pskb_website/api.py
@@ -3,6 +3,9 @@ Collection of URLs returning JSON responses
 """
 
 import os
+import re
+
+import requests
 
 from flask import Response, url_for, request, flash, json, g
 
@@ -171,4 +174,23 @@ def img_upload():
         return Response(response='', status=500, mimetype='application/json')
 
     return Response(response=json.dumps(url), status=200,
+                    mimetype='application/json')
+
+
+@app.route('/api/slack_stats/', methods=['GET'])
+def slack_stats():
+    """
+    Screen-scrape slack signup app since it's dynamic with node.js and grabs
+    from slack API.
+    """
+
+    stats = ''
+    resp = requests.get(SLACK_URL)
+
+    if resp.status_code == 200:
+        user_count = re.search(r'<p class="status">(.*?)</p>', resp.content)
+        if user_count is not None:
+            stats = user_count.group(1)
+
+    return Response(response=json.dumps({'text': stats}), status=200,
                     mimetype='application/json')

--- a/pskb_website/api.py
+++ b/pskb_website/api.py
@@ -20,8 +20,12 @@ from .lib import login_required
 @app.route('/api/save/', methods=['POST'])
 @login_required
 def api_save():
-    """Api: POST /api/save {path:'', title: '', sha:'', original_stack: '', content: '', stacks: []}"""
+    """
+    Api: POST /api/save
+    {path:'', title: '', sha:'', original_stack: '', content: '', stacks: []}
+    """
 
+    # Used to show link to slack for authors to get feedback
     g.slack_url = SLACK_URL
 
     user = models.find_user()

--- a/pskb_website/static/js/utils.js
+++ b/pskb_website/static/js/utils.js
@@ -225,3 +225,26 @@ function init_signup_row(scroll_pos, signup_type) {
         $('#signup-row').hide();
     });
 }
+
+
+/* Update given element with slack stats asychronously */
+function show_slack_stats(element) {
+    $.ajax({
+        type: 'GET',
+        url: '/api/slack_stats/',
+        contentType: 'application/x-www-form-urlencoded; charset=UTF-8',
+        dataType: 'json',
+        cache: false,
+        success: function(data) {
+            if (data.text) {
+                element.html(data.text);
+            }
+        },
+        /* Don't bother doing anything on error. These stats aren't essential. */
+        error: function(response) {
+            var status = response.status;
+            var data = response.responseJSON;
+            console.log(status, data);
+        },
+    });
+}

--- a/pskb_website/templates/faq.html
+++ b/pskb_website/templates/faq.html
@@ -19,6 +19,7 @@
 
 <script type="text/javascript">
     init_signup_row(600, "slack");
+    show_slack_stats($('#slack_stats'));
 </script>
 
 {% endblock %}

--- a/pskb_website/templates/slack_signup.html
+++ b/pskb_website/templates/slack_signup.html
@@ -1,7 +1,7 @@
                     <div class="col-md-11 col-xs-11">
                         <div class="slack-signup center-block">
                             <h4>Join hack.guides() on Slack.</h4>
-                            <p> {{g.slack_stats|safe}} </p>
+                            <p id="slack_stats"></p>
                             <p><a href="{{g.slack_url}}" target="_blank">Get my invite</a></p>
                         </div>
                     </div>

--- a/pskb_website/views.py
+++ b/pskb_website/views.py
@@ -2,10 +2,6 @@
 Main views of PSKB app
 """
 
-import re
-
-import requests
-
 from flask import redirect, url_for, session, request, render_template, flash, g
 
 from . import PUBLISHED, IN_REVIEW, DRAFT, STATUSES, SLACK_URL
@@ -105,16 +101,7 @@ def faq():
     text = models.read_file('faq.md', rendered_text=True, use_cache=True,
                             timeout=60 * 60)
 
-    # Screen-scrape slack signup app since it's dynamic with node.js and grabs
-    # from slack API.
-
-    resp = requests.get(g.slack_url)
-    if resp.status_code == 200:
-        user_count = re.search(r'<p class="status">(.*?)</p>', resp.content)
-        if user_count is not None:
-            g.slack_stats = user_count.group(1)
-
-    return render_template('faq.html', text=text)
+    return render_template('faq.html')
 
 
 @app.route('/github_login')

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ Flask-Script==2.0.5
 celery==3.1.20
 pytest==2.8.7
 requests==2.9.1
+newrelic==2.64.0.48


### PR DESCRIPTION
Went ahead and implemented the API/async approach since it was pretty easy.  This still can hang a request on our server for a few seconds while we wait for the heroku instance to spin up.  However, the page itself will load first.  Now the users can start reading the text and we'll deal with the inessential slack stats in the background.
