### PR TITLE
Branching by guide

### DIFF
--- a/docs/github_repo_layout.rst
+++ b/docs/github_repo_layout.rst
@@ -135,8 +135,8 @@ Branches
 --------
 
 Branches are currently used for suggested 'edits' to guides by the community
-editors.  The branches are named after the github login name of the user whose
-edits triggered the creation.
+editors.  The branches are named to match the editor's login, stack, and title
+of the guide.
 
 Each time a user edits an existing users' guide a branch is created (or
 updated).  You can easily use `Github's compare functionality <https://github.com/blog/612-introducing-github-compare-view>`_ to see the edits a particular user is suggesting.

--- a/pskb_website/templates/article.html
+++ b/pskb_website/templates/article.html
@@ -159,14 +159,14 @@
                 {% if article.branch != 'master' %}
                     <li>
                         See {{article.author_name}}'s <a href="{{article|url_for_article(branch='master')}}">original version of this guide</a> or
-                        {{article.branch}}'s <a href="https://github.com/{{article.repo_path}}/compare/master...{{article.branch}}" target="_blank">suggestions on github</a>.
+                        these <a href="https://github.com/{{article.repo_path}}/compare/master...{{article.branch}}" target="_blank">suggestions on github</a>.
                     </li>
                 {% endif %}
 
-                {% for branch in branches %}
-                    {% if branch != 'master' and branch != article.branch %}
+                {% for branch_author, branch_name in branches %}
+                    {% if branch_name != 'master' and branch_name != article.branch %}
                         <li>
-                            See {{branch}}'s <a href="{{article|url_for_article(branch=branch)}}"> version of this guide</a> or their <a href="https://github.com/{{article.repo_path}}/compare/master...{{branch}}"
+                            See {{branch_author}}'s <a href="{{article|url_for_article(branch=branch_name)}}"> version of this guide</a> or their <a href="https://github.com/{{article.repo_path}}/compare/master...{{branch_name}}"
                     target="_blank">suggestions on github</a>.
                         </li>
                     {% endif %}

--- a/pskb_website/templates/editor_help.html
+++ b/pskb_website/templates/editor_help.html
@@ -10,8 +10,12 @@
             <ul>
                 <li>Saving a guide sends it straight to our official <a href="{{repo_url}}" target="_blank">Github repository</a> where editors around the world can help.</li>
                 <li>
-                    Your guide is in the master branch of our <a href="{{repo_url}}" target="_blank">Github repository</a> unless you're editing a guide started by someone else.  In that case, a branch named after your username is created.  The original author can see your suggested changes directly on Github.
+                {% if article and article.author_name != username %}
+                    Your guide will be in a new branch of our <a href="{{repo_url}}" target="_blank">Github repository</a>.  The original author can review the changes there.
+                {% else %}
+                    Your guide will be in the master branch of our <a href="{{repo_url}}" target="_blank">Github repository</a>.
                 </li>
+                {% endif %}
                 <li>
                     Once our editors decide your guide is ready, we'll put it on our <a href="{{url_for('index')}}" target="_blank">homepage</a> to help educate the world.
                 </li>

--- a/pskb_website/templates/editor_workflow.html
+++ b/pskb_website/templates/editor_workflow.html
@@ -1,0 +1,13 @@
+    <h1 id="thanks">Thanks for editing {{article.title}}!</h1>
+    <h3>1. Done editing?</h3>
+    <p>
+        If so, <a href="https://github.com/{{article.repo_path}}/compare/{{article.branch}}" target="_blank"> click here to open a Pull Request on Github.</a>&nbsp;&nbsp;&nbsp;
+        This notifies {{article.author_real_name if article.author_real_name else article.author_name}}
+        about your suggestions.  Look for feedback directly on github.com.
+    </p>
+    <h3>2. Not done yet?</h3>
+    <p>
+        No worries, just come back to this page when you're ready and
+        make additional changes.  The changes will be saved right
+        alongside these edits.
+    </p>

--- a/pskb_website/templates/publish_workflow.html
+++ b/pskb_website/templates/publish_workflow.html
@@ -1,5 +1,6 @@
 <div id="workflow-help" class="bg-success">
 {% if status == 'draft' %}
+    {% if article.branch == 'master' %}
     <h1 id="thanks">Thanks for posting your new guide!</h1>
     <p>
         The guide is now in <strong>draft</strong> status, which means it's
@@ -15,7 +16,11 @@
         <a href="{{g.slack_url}}">Slack channel</a> or
         <a href="mailto: prateek-gupta@pluralsight.com">contact us directly</a>.
     </p>
+    {% else %}
+    {% include 'editor_workflow.html' %}
+    {% endif %}
 {% elif status == 'in-review' %}
+    {% if article.branch == 'master' %}
     <h1 id="thanks">Thanks for posting your new guide!</h1>
     <p>
         The guide is now in <strong>in-review</strong> status, which means it
@@ -58,8 +63,12 @@
             </span>
         </div>
     </div>
+    {% else %}
+    {% include 'editor_workflow.html' %}
+    {% endif %}
 
 {% elif status == 'published' %}
+    {% if article.branch == 'master' %}
     <h1 id="thanks">This guide is now published!</h1>
     <p>
         Your content is being saved to Github. It should appear within a few
@@ -94,6 +103,9 @@
             </span>
         </div>
     </div>
+    {% else %}
+    {% include 'editor_workflow.html' %}
+    {% endif %}
 {% endif %}
 </div>
 

--- a/pskb_website/views.py
+++ b/pskb_website/views.py
@@ -226,6 +226,8 @@ def write(article_path):
     article = None
     selected_stack = None
 
+    username = session['login']
+
     if article_path is not None:
         branch = request.args.get('branch', u'master')
         article = models.read_article(article_path, rendered_text=False,
@@ -248,7 +250,7 @@ def write(article_path):
 
     return render_template('editor.html', article=article,
                            stacks=forms.STACK_OPTIONS,
-                           selected_stack=selected_stack)
+                           selected_stack=selected_stack, username=username)
 
 
 @app.route('/partner/import/')

--- a/pskb_website/views.py
+++ b/pskb_website/views.py
@@ -444,7 +444,7 @@ def render_article_view(request_obj, article, only_visible_by_user=None):
 
     # Always include a link to original article if this is a branched version
     if article.branch != u'master':
-        branches.append(u'master')
+        branches.append([article.author_name, u'master'])
 
     g.header_white = True
 


### PR DESCRIPTION
Now branches are created for each guide an editor submits an edit for instead of storing all their edits in a single branch.  This makes it much easier to merge/create pull requests since each branch will touch at most 1 guide at a time.
