### PR TITLE
Fixes of PR #56

### DIFF
--- a/pskb_website/static/css/vendor/editor/design.css
+++ b/pskb_website/static/css/vendor/editor/design.css
@@ -84,7 +84,8 @@
 
 .editor-header .btn-save,
 .editor-header .btn-options,
-.editor-header .btn-back {
+.editor-header .btn-back,
+.editor-header .btn-close {
     float: right;
     margin-right: 10px;
 }

--- a/pskb_website/static/css/vendor/editor/design.css
+++ b/pskb_website/static/css/vendor/editor/design.css
@@ -84,7 +84,7 @@
 
 .editor-header .btn-save,
 .editor-header .btn-options,
-.editor-header .btn-cancel {
+.editor-header .btn-back {
     float: right;
     margin-right: 10px;
 }

--- a/pskb_website/static/js/editor_utils.js
+++ b/pskb_website/static/js/editor_utils.js
@@ -356,6 +356,7 @@ function closeLiveMarkdownTutorial() {
     editor.setValue(loadAutoSave(current_local_filename) || '');
     autosaveEnabled = true;
     $('#btn-save').prop('disabled', false);
+    editor.gotoLine(1);
 }
 
 function toggleLiveTutorial() {

--- a/pskb_website/static/js/editor_utils.js
+++ b/pskb_website/static/js/editor_utils.js
@@ -350,9 +350,7 @@ function openLiveMarkdownTutorial() {
     liveTutorialEnabled = true;
     autosaveEnabled = false;
     editor.getSession().setValue(MARKDOWN_TUTORIAL);
-    $('#btn-save').parent().tooltip('destroy');
     $('#btn-save').prop('disabled', true);
-    $('#btn-save').parent().tooltip({title: 'Live Markdown Tutorial enabled'});
 }
 
 function closeLiveMarkdownTutorial() {
@@ -361,8 +359,6 @@ function closeLiveMarkdownTutorial() {
     editor.gotoLine(1);
     autosaveEnabled = true;
     $('#btn-save').prop('disabled', false);
-    $('#btn-save').parent().attr('title', '');
-    $('#btn-save').parent().tooltip('destroy');
     enableDisableSaveButton();
 }
 
@@ -423,13 +419,9 @@ function enableDisableSaveButton() {
         var title = $('input[name=title]').val();
         var stack = $('#stacks').val();
         if (! (title && stack)) {
-            $('#btn-save').parent().tooltip('destroy');
             $('#btn-save').prop('disabled', true);
-            $('#btn-save').parent().tooltip({title: 'Please, choose a title and a stack before saving the article.'});
         } else {
             $('#btn-save').prop('disabled', false);
-            $('#btn-save').parent().attr('title', '');
-            $('#btn-save').parent().tooltip('destroy');
         }
     }
 }

--- a/pskb_website/static/js/editor_utils.js
+++ b/pskb_website/static/js/editor_utils.js
@@ -349,13 +349,13 @@ function configure_dropzone_area(img_upload_url) {
 function openLiveMarkdownTutorial() {
     autosaveEnabled = false;
     editor.getSession().setValue(MARKDOWN_TUTORIAL);
-    $('.btn-save').prop('disabled', true);
+    $('#btn-save').prop('disabled', true);
 }
 
 function closeLiveMarkdownTutorial() {
     editor.setValue(loadAutoSave(current_local_filename) || '');
     autosaveEnabled = true;
-    $('.btn-save').prop('disabled', false);
+    $('#btn-save').prop('disabled', false);
 }
 
 function toggleLiveTutorial() {
@@ -437,21 +437,25 @@ function save(sha, path, secondary_repo) {
         dataType: 'json',
         cache: false,
         beforeSend: function(xhr) {
-            $('.btn-save').prop('disabled', true);
             $('html, body').css("cursor", "wait");
+            $('#editor-options').prop('disabled', true);
+            $('#btn-back').prop('disabled', true);
+            $('#btn-save').prop('disabled', true);
             return true;
         },
         complete: function(xhr, txt_status) {
-            $('html, body').css("cursor", "auto");
-            $('.btn-save').prop('disabled', false);
         },
         success: function(data) {
             console.log(data);
             console.log(data.msg);
             clearLocalSave(current_local_filename);
-            setTimeout(function(){ window.location.href = data.redirect; }, 1000);
+            window.location.href = data.redirect;
         },
         error: function(response) {
+            $('html, body').css("cursor", "auto");
+            $('#editor-options').prop('disabled', true);
+            $('#btn-back').prop('disabled', true);
+            $('#btn-save').prop('disabled', true);
             var status = response.status;
             var data = response.responseJSON;
             console.log(status, data);

--- a/pskb_website/static/js/editor_utils.js
+++ b/pskb_website/static/js/editor_utils.js
@@ -347,6 +347,7 @@ function configure_dropzone_area(img_upload_url) {
 }
 
 function openLiveMarkdownTutorial() {
+    liveTutorialEnabled = true;
     autosaveEnabled = false;
     editor.getSession().setValue(MARKDOWN_TUTORIAL);
     $('#btn-save').parent().tooltip('destroy');
@@ -355,12 +356,14 @@ function openLiveMarkdownTutorial() {
 }
 
 function closeLiveMarkdownTutorial() {
+    liveTutorialEnabled = false;
     editor.setValue(loadAutoSave(current_local_filename) || '');
     editor.gotoLine(1);
     autosaveEnabled = true;
     $('#btn-save').prop('disabled', false);
     $('#btn-save').parent().attr('title', '');
     $('#btn-save').parent().tooltip('destroy');
+    enableDisableSaveButton();
 }
 
 function toggleLiveTutorial() {
@@ -369,7 +372,6 @@ function toggleLiveTutorial() {
     } else {
         openLiveMarkdownTutorial();
     }
-    liveTutorialEnabled = ! liveTutorialEnabled;
 }
 
 function scrollPreviewAccordingToEditor(scrollTop) {
@@ -415,6 +417,22 @@ function resizeEditor() {
     editor.setOption('maxLines', Math.floor(maxLines));
     editor.resize();
 };
+
+function enableDisableSaveButton() {
+    if (! liveTutorialEnabled) {
+        var title = $('input[name=title]').val();
+        var stack = $('#stacks').val();
+        if (! (title && stack)) {
+            $('#btn-save').parent().tooltip('destroy');
+            $('#btn-save').prop('disabled', true);
+            $('#btn-save').parent().tooltip({title: 'Please, choose a title and a stack before saving the article.'});
+        } else {
+            $('#btn-save').prop('disabled', false);
+            $('#btn-save').parent().attr('title', '');
+            $('#btn-save').parent().tooltip('destroy');
+        }
+    }
+}
 
 /* This requires Twitter bootstraps Modal.js! */
 var addModalMessage = function(message) {

--- a/pskb_website/static/js/editor_utils.js
+++ b/pskb_website/static/js/editor_utils.js
@@ -350,7 +350,11 @@ function openLiveMarkdownTutorial() {
     liveTutorialEnabled = true;
     autosaveEnabled = false;
     editor.getSession().setValue(MARKDOWN_TUTORIAL);
-    $('#btn-save').prop('disabled', true);
+
+    $('.tutorial-title, #btn-close').show();
+    $('#article-title, #article-stack, #title, #stacks').hide();
+    $('[data-id="stacks"]').parent().hide();
+    $('#btn-save, #btn-back').hide();
 }
 
 function closeLiveMarkdownTutorial() {
@@ -358,7 +362,12 @@ function closeLiveMarkdownTutorial() {
     editor.setValue(loadAutoSave(current_local_filename) || '');
     editor.gotoLine(1);
     autosaveEnabled = true;
-    $('#btn-save').prop('disabled', false);
+
+    $('.tutorial-title, #btn-close').hide();
+    $('#article-title, #article-stack, #title, #stacks').show();
+    $('[data-id="stacks"]').parent().show();
+    $('#btn-save, #btn-back').show();
+
     enableDisableSaveButton();
 }
 
@@ -469,8 +478,8 @@ function save(sha, path, secondary_repo) {
         error: function(response) {
             $('html, body').css("cursor", "auto");
             $('#editor-options').prop('disabled', true);
-            $('#btn-back').prop('disabled', true);
-            $('#btn-save').prop('disabled', true);
+            $('#btn-back').prop('disabled', false);
+            $('#btn-save').prop('disabled', false);
             var status = response.status;
             var data = response.responseJSON;
             console.log(status, data);

--- a/pskb_website/static/js/editor_utils.js
+++ b/pskb_website/static/js/editor_utils.js
@@ -349,14 +349,18 @@ function configure_dropzone_area(img_upload_url) {
 function openLiveMarkdownTutorial() {
     autosaveEnabled = false;
     editor.getSession().setValue(MARKDOWN_TUTORIAL);
+    $('#btn-save').parent().tooltip('destroy');
     $('#btn-save').prop('disabled', true);
+    $('#btn-save').parent().tooltip({title: 'Live Markdown Tutorial enabled'});
 }
 
 function closeLiveMarkdownTutorial() {
     editor.setValue(loadAutoSave(current_local_filename) || '');
+    editor.gotoLine(1);
     autosaveEnabled = true;
     $('#btn-save').prop('disabled', false);
-    editor.gotoLine(1);
+    $('#btn-save').parent().attr('title', '');
+    $('#btn-save').parent().tooltip('destroy');
 }
 
 function toggleLiveTutorial() {

--- a/pskb_website/templates/editor.html
+++ b/pskb_website/templates/editor.html
@@ -43,6 +43,8 @@
 
                 <button id="btn-back" onclick="back()" class="btn btn-danger btn-back btn-autosize">Back</button>
 
+                <button id="btn-close" onclick="closeLiveMarkdownTutorial()" class="btn btn-info btn-close btn-autosize" style="display:none;">Close tutorial</button>
+
                 <div class="dropdown">
                     <button id="editor-options" class="btn btn-info btn-options btn-autosize" data-target="#" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
                         Options
@@ -66,6 +68,8 @@
                 </div>
 
                 <br style="clear: both;"/>
+
+                <h4 class="tutorial-title" style="display:none; text-align:center;">Live Markdown Tutorial</h4>
 
                 <input id="title" name="title" type="text" placeholder="Title" data-toggle="tooltip" data-placement="bottom" title="Concise and descriptive, a good title is 130 characters or less" is 130 charmaxlength="130" value="{{article.title}}" {{'readOnly="true"' if article else ""}} {% if not article %}autofocus{% endif %} required="required"/>
                 <input id="original_stack" name="original_stack" type="hidden" value="{{article.stacks[0] if article else ''}}" />
@@ -98,6 +102,7 @@
         <div class="col-xs-12 col-sm-6 preview-column">
             <div class="preview-header">
                 <div class="preview-text hidden-xs hidden-sm">PREVIEW</div>
+                <h4 class="tutorial-title" style="display:none;">Live Markdown Tutorial</h4>
                 <div id="article-title" class=""></div>
                 <div id="article-stack" class=""></div>
             </div>

--- a/pskb_website/templates/editor.html
+++ b/pskb_website/templates/editor.html
@@ -39,8 +39,8 @@
                     <img src="/static/img/light-logo.png" alt="hack.guides()" class="editor-ps-logo img-responsive">
                 </a>
 
-                <button onclick="save('{{article.sha}}', '{{article.path}}', '{{secondary_repo}}')" class="btn btn-primary btn-save btn-autosize">Save</button>
-                <button onclick="cancel()" class="btn btn-danger btn-cancel btn-autosize">Cancel</button>
+                <button id="btn-save" onclick="save('{{article.sha}}', '{{article.path}}', '{{secondary_repo}}')" class="btn btn-primary btn-save btn-autosize">Save</button>
+                <button id="btn-back" onclick="back()" class="btn btn-danger btn-back btn-autosize">Back</button>
 
                 <div class="dropdown">
                     <button id="editor-options" class="btn btn-info btn-options btn-autosize" data-target="#" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
@@ -109,7 +109,7 @@
 {% include "editor_error.html" %}
 
 <script type="text/javascript">
-    function cancel() {
+    function back() {
         {% if article %}
             window.location.href = "{{article|url_for_article(branch=article.branch)}}";
         {% else %}

--- a/pskb_website/templates/editor.html
+++ b/pskb_website/templates/editor.html
@@ -39,9 +39,8 @@
                     <img src="/static/img/light-logo.png" alt="hack.guides()" class="editor-ps-logo img-responsive">
                 </a>
 
-                <div data-toggle="tooltip" data-placement="bottom" style="display: inline-block; float: right; padding:1px;">
-                    <button id="btn-save" onclick="save('{{article.sha}}', '{{article.path}}', '{{secondary_repo}}')" class="btn btn-primary btn-save btn-autosize">Save</button>
-                </div>
+                <button id="btn-save" onclick="save('{{article.sha}}', '{{article.path}}', '{{secondary_repo}}')" class="btn btn-primary btn-save btn-autosize">Save</button>
+
                 <button id="btn-back" onclick="back()" class="btn btn-danger btn-back btn-autosize">Back</button>
 
                 <div class="dropdown">

--- a/pskb_website/templates/editor.html
+++ b/pskb_website/templates/editor.html
@@ -133,10 +133,12 @@
 
         $("#title").change(function() {
             $("#article-title").html($("#title").val() || 'Untitled');
+            enableDisableSaveButton();
         });
         $("#stacks").change(function() {
             var stacks = $('#stacks').val();
             $("#article-stack").html(stacks ? 'Related to <i>' + stacks + '</i>' : 'no stack defined yet');
+            enableDisableSaveButton();
         });
         $("#title").change();
         $("#stacks").change();

--- a/pskb_website/templates/editor.html
+++ b/pskb_website/templates/editor.html
@@ -39,7 +39,9 @@
                     <img src="/static/img/light-logo.png" alt="hack.guides()" class="editor-ps-logo img-responsive">
                 </a>
 
-                <button id="btn-save" onclick="save('{{article.sha}}', '{{article.path}}', '{{secondary_repo}}')" class="btn btn-primary btn-save btn-autosize">Save</button>
+                <div data-toggle="tooltip" data-placement="bottom" style="display: inline-block; float: right; padding:1px;">
+                    <button id="btn-save" onclick="save('{{article.sha}}', '{{article.path}}', '{{secondary_repo}}')" class="btn btn-primary btn-save btn-autosize">Save</button>
+                </div>
                 <button id="btn-back" onclick="back()" class="btn btn-danger btn-back btn-autosize">Back</button>
 
                 <div class="dropdown">


### PR DESCRIPTION
Fast redirection after successfully saving an article. Don't re-enable the buttons in case of success. Also, renamed the Cancel button to Back.

More:
- Stop using tooltips on disabled button.
- Better live markdown tutorial interface

https://github.com/pluralsight/guides-cms/pull/56#issuecomment-217100436
