### PR TITLE
Webhooks integration

### DIFF
--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -100,6 +100,8 @@ Redis for background tasks
     * `heroku config:set CELERY_BROKER_URL=<REDIS_URL>`
 * We don't set `CELERY_BROKER_URL` directly equal to `REDIS_URL` so that you're free to setup Celery with whatever broker you choose.
 
+.. _redis_caching:
+
 Adding Redis caching on Heroku
 ------------------------------
 

--- a/docs/github_webhooks.rst
+++ b/docs/github_webhooks.rst
@@ -11,8 +11,8 @@ directly so that the CMS is always using the most up-to-date guide information.
 Configuring Push Events
 -----------------------
 
-This event is specifically used to clear the cache of a guide when it's changed
-via a commit from the Github API and/or Github.com
+This event is used to clear the cache of a guide when it's changed via a commit
+from the Github API and/or Github.com
 
 1. Go to the settings area of your content repository where all of your guides
    are stored and click on 'Webhooks & services'.
@@ -20,9 +20,26 @@ via a commit from the Github API and/or Github.com
 3. Set the `Payload URL` to `<your_domain>/github_push`
 4. The `Content type` should be `application/json`
 5. **Leave `Secret` blank**
-6. Only subscript to the push event
+6. Only subscribe to the push event
 7. Make sure the webhook is marked as **active**
 8. Click 'Add webhook'
+
+Configuring Delete Events
+-------------------------
+
+This event is used to clean up the list of branches associated with a guide.
+
+1. Go to the settings area of your content repository where all of your guides
+   are stored and click on 'Webhooks & services'.
+2. Click 'Add webhook'
+3. Set the `Payload URL` to `<your_domain>/github_push`
+4. The `Content type` should be `application/json`
+5. **Leave `Secret` blank**
+6. Only subscript to the delete event
+    - Click 'Let me select individual events'
+7. Make sure the webhook is marked as **active**
+8. Click 'Add webhook'
+
 
 Testing
 -------

--- a/docs/github_webhooks.rst
+++ b/docs/github_webhooks.rst
@@ -1,0 +1,30 @@
+===============
+Github Webhooks
+===============
+
+The CMS uses `Github webhooks <https://developer.github.com/webhooks/>`_ to
+get notifications of changes happening on Github.com.  These are not required,
+but they are useful if you're using the built-in :ref:`Caching <redis_caching>`.
+These webhooks can clear the cache when something changes on Github.com
+directly so that the CMS is always using the most up-to-date guide information.
+
+Configuring Push Events
+-----------------------
+
+This event is specifically used to clear the cache of a guide when it's changed
+via a commit from the Github API and/or Github.com
+
+1. Go to the settings area of your content repository where all of your guides
+   are stored and click on 'Webhooks & services'.
+2. Click 'Add webhook'
+3. Set the `Payload URL` to `<your_domain>/github_push`
+4. The `Content type` should be `application/json`
+5. **Leave `Secret` blank**
+6. Only subscript to the push event
+7. Make sure the webhook is marked as **active**
+8. Click 'Add webhook'
+
+Testing
+-------
+
+Github has `great documentation on testing webhooks <https://developer.github.com/webhooks/testing/>`_ and `a solution for testing locally <https://developer.github.com/webhooks/creating>`_.

--- a/docs/github_webhooks.rst
+++ b/docs/github_webhooks.rst
@@ -19,10 +19,12 @@ from the Github API and/or Github.com
 2. Click 'Add webhook'
 3. Set the `Payload URL` to `<your_domain>/github_push`
 4. The `Content type` should be `application/json`
-5. **Leave `Secret` blank**
+5. Setup your *secret* field according to `Github's instructions <https://developer.github.com/webhooks/securing/>`_ or use the same *secret* you configured for Delete Events if you configured those first.
 6. Only subscribe to the push event
 7. Make sure the webhook is marked as **active**
 8. Click 'Add webhook'
+9. Add a new environment variable to your you instance of the CMS called
+   WEBHOOK_SECRET and set it to the value you used in step 5.
 
 Configuring Delete Events
 -------------------------
@@ -34,12 +36,16 @@ This event is used to clean up the list of branches associated with a guide.
 2. Click 'Add webhook'
 3. Set the `Payload URL` to `<your_domain>/github_push`
 4. The `Content type` should be `application/json`
-5. **Leave `Secret` blank**
+5. Setup your *secret* field according to `Github's instructions <https://developer.github.com/webhooks/securing/>`_ or use the same *secret* you configured for Push Events above.
 6. Only subscript to the delete event
     - Click 'Let me select individual events'
 7. Make sure the webhook is marked as **active**
 8. Click 'Add webhook'
+9. Add a new environment variable to your you instance of the CMS called
+   WEBHOOK_SECRET and set it to the value you used in step 5.
 
+**The same secret is used for all webhooks for simplicity and to cutdown on the
+number of environment variables needed.**
 
 Testing
 -------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,11 +18,12 @@ Contents:
    install
    testing
    github_setup
+   github_repo_layout
    deployment
    publish_workflow
    merging_changes
    github_api_usage
-   github_repo_layout
+   github_webhooks
    faq
    views
    model_api

--- a/example_config.py
+++ b/example_config.py
@@ -16,7 +16,7 @@ HEROKU_ENV_REQUIREMENTS = ('HEROKU', 'SECRET_KEY', 'GITHUB_CLIENT_ID',
                            'SECONDARY_REPO_OWNER', 'SECONDARY_REPO_NAME',
                            'DOMAIN', 'CELERY_BROKER_URL',
                            'CELERY_TASK_SERIALIZER', 'HOSTING_SUBDIRECTORY',
-                           'IGNORE_STATS_FOR')
+                           'IGNORE_STATS_FOR', 'WEBHOOK_SECRET')
 
 
 class Config(object):
@@ -51,6 +51,9 @@ class Config(object):
     MAILCHIMP_STACKS_GROUP_NAME = None
 
     DOMAIN = ''
+
+    # Only needed if using github webhooks
+    WEBHOOK_SECRET = ''
 
     # Set this to something like '/guides' if your hosting this application on
     # a subdirectory with a proxy pass rule that sends all /guides/* requests

--- a/pskb_website/__init__.py
+++ b/pskb_website/__init__.py
@@ -66,6 +66,7 @@ if not app.debug:
 
 import pskb_website.views
 import pskb_website.api
+import pskb_website.webhooks
 import pskb_website.filters
 
 app.jinja_env.filters['date_string'] = filters.date_string

--- a/pskb_website/lib.py
+++ b/pskb_website/lib.py
@@ -2,13 +2,12 @@
 Collection of functions for general use
 """
 
-import os
 from functools import wraps
 from urlparse import urlparse
 
 from flask import redirect, url_for, session, request, flash
 
-from . import PUBLISHED, STATUSES
+from . import STATUSES
 from . import app
 from . import models
 

--- a/pskb_website/lib.py
+++ b/pskb_website/lib.py
@@ -8,9 +8,49 @@ from urlparse import urlparse
 
 from flask import redirect, url_for, session, request, flash
 
-from . import PUBLISHED
+from . import PUBLISHED, STATUSES
 from . import app
 from . import models
+
+
+def read_article(stack, title, branch, status, rendered_text=True):
+    """
+    Read article by checking all possible statuses, starting with given status
+
+    :param stack: Article stack
+    :param title: Article title
+    :param branch: Article branch
+    :param status: First status to check for article
+    :returns: Article object or None if not found
+
+    This is a small wrapper around models.read_article to handle the common
+    task of reading an article's text regardless of where it is in the publish
+    status workflow. models.read_article requires the path to the publish
+    status.
+    """
+
+    # Using a list here because we specifically want to check in this order but
+    # we don't want to check a single status more than once so don't want dups
+    # either.
+    statuses_to_check = [status]
+    for possible_status in STATUSES:
+        if possible_status not in statuses_to_check:
+            statuses_to_check.append(possible_status)
+
+    article = None
+    for status in statuses_to_check:
+        path = u'%s/%s/%s' % (status, stack, title)
+
+        # allow_missing is a workaround when we're looking for an article from
+        # old /review/ URL b/c we don't know what the status is we have to
+        # check them all.  We don't want to log things as missing if we didn't
+        # know where they were and had to check all locations.
+        article = models.read_article(path, branch=branch, allow_missing=True,
+                                      rendered_text=rendered_text)
+        if article is not None:
+            break
+
+    return article
 
 
 def is_logged_in():

--- a/pskb_website/models/article.py
+++ b/pskb_website/models/article.py
@@ -23,6 +23,7 @@ from .. import utils
 FILE_EXTENSION = '.md'
 ARTICLE_FILENAME = 'article%s' % (FILE_EXTENSION)
 ARTICLE_METADATA_FILENAME = 'details.json'
+DEFAULT_STACK = u'other'
 
 path_details = collections.namedtuple('path_details', 'repo, filename')
 
@@ -885,7 +886,7 @@ class Article(object):
 
         self.title = title
         self.author_name = author_name
-        self.stacks = stacks or [u'other']
+        self.stacks = stacks or [DEFAULT_STACK]
         self.content = content
         self.external_url = external_url
         self.filename = filename
@@ -1008,7 +1009,7 @@ class Article(object):
 
             # This field used to be optional
             elif attr == 'stacks' and not value:
-                value = [u'other']
+                value = [DEFAULT_STACK]
 
             # Backwards compatability. We used to only store a list of branch
             # names b/c branches were named after editor. Now branches are

--- a/pskb_website/models/article.py
+++ b/pskb_website/models/article.py
@@ -414,6 +414,7 @@ def save_article(title, message, new_content, author_name, email, sha,
                       stacks=stacks)
     article.publish_status = status
     article.first_commit = first_commit
+    article.content = new_content
 
     commit_sha = remote.commit_file_to_github(article.full_path, message,
                                               new_content, author_name, email,
@@ -436,9 +437,7 @@ def save_article(title, message, new_content, author_name, email, sha,
         return commit_sha
 
     _delete_article_from_cache(article)
-
-    return read_article(article.path, rendered_text=True,
-                        branch=article.branch, repo_path=repo_path)
+    return article
 
 
 def branch_article(article, message, new_content, author_name, email,

--- a/pskb_website/models/article.py
+++ b/pskb_website/models/article.py
@@ -762,9 +762,6 @@ def delete_article(article, message, name, email):
                                           name, email, article.branch):
         return False
 
-    # FIXME: Need to update the cache reference to the original article so we
-    # don't think this branch still exists in cache.
-
     return True
 
 

--- a/pskb_website/remote.py
+++ b/pskb_website/remote.py
@@ -363,6 +363,10 @@ def commit_file_to_github(path, message, content, name, email, sha=None,
     :param auto_encode: Boolean to automatically encode data as utf-8
 
     :returns: SHA of commit or None for failure
+
+    Note that name and email can be None if you want to make a commit with the
+    REPO_OWNER.  However, name and email should both exist or both be None,
+    which is a requirement of the underlying Github API.
     """
 
     url = contents_url_from_path(path)
@@ -370,9 +374,13 @@ def commit_file_to_github(path, message, content, name, email, sha=None,
     if auto_encode:
         content = base64.b64encode(content.encode('utf-8'))
 
-    commit_info = {'message': message, 'content': content, 'branch': branch,
-                   'author': {'name': name, 'email': email},
-                   'committer': {'name': name, 'email': email}}
+    commit_info = {'message': message, 'content': content, 'branch': branch}
+
+    if name is not None and email is not None:
+        commit_info['author'] = {'name': name, 'email': email}
+        commit_info['committer'] = {'name': name, 'email': email}
+    elif (name is None and email is not None) or (name is not None and email is None):
+        raise ValueError('Must specify both name and email or neither')
 
     if sha:
         commit_info['sha'] = sha

--- a/pskb_website/views.py
+++ b/pskb_website/views.py
@@ -13,6 +13,7 @@ from . import tasks
 from . import filters
 from . import utils
 from .lib import (
+        read_article,
         login_required,
         is_logged_in,
         lookup_url_redirect,
@@ -735,43 +736,3 @@ def missing_article(requested_url=None, stack=None, title=None, branch=None):
 
     flash('We could not find that guide. Give these fresh ones a try.')
     return render_published_articles(status_code=404)
-
-
-def read_article(stack, title, branch, status, rendered_text=True):
-    """
-    Read article by checking all possible statuses, starting with given status
-
-    :param stack: Article stack
-    :param title: Article title
-    :param branch: Article branch
-    :param status: First status to check for article
-    :returns: Article object or None if not found
-
-    This is a small wrapper around models.read_article to handle the common
-    task of reading an article's text regardless of where it is in the publish
-    status workflow. models.read_article requires the path to the publish
-    status.
-    """
-
-    # Using a list here because we specifically want to check in this order but
-    # we don't want to check a single status more than once so don't want dups
-    # either.
-    statuses_to_check = [status]
-    for possible_status in STATUSES:
-        if possible_status not in statuses_to_check:
-            statuses_to_check.append(possible_status)
-
-    article = None
-    for status in statuses_to_check:
-        path = u'%s/%s/%s' % (status, stack, title)
-
-        # allow_missing is a workaround when we're looking for an article from
-        # old /review/ URL b/c we don't know what the status is we have to
-        # check them all.  We don't want to log things as missing if we didn't
-        # know where they were and had to check all locations.
-        article = models.read_article(path, branch=branch, allow_missing=True,
-                                      rendered_text=rendered_text)
-        if article is not None:
-            break
-
-    return article

--- a/pskb_website/views.py
+++ b/pskb_website/views.py
@@ -341,7 +341,7 @@ def article_view(stack, title):
     # Branches are deleted once they are accepted or rejected so show the
     # master if we can find it.
     if branch != u'master':
-        flash('Unable to find %s\'s branch, maybe their changes were accepted into the master branch below.' % (branch),
+        flash('Unable to find %s branch, maybe those changes were accepted into the master branch below.' % (branch),
               category='info')
 
         # Master is default branch so don't bother including, just for cleaner

--- a/pskb_website/webhooks.py
+++ b/pskb_website/webhooks.py
@@ -1,0 +1,77 @@
+"""
+Collection of URLs responding to Github webhooks API
+"""
+
+import json
+
+from . import app
+from . import cache
+from .models.article import ARTICLE_FILENAME
+
+from flask import request, Response
+
+
+@app.route('/github_push', methods=['POST'])
+def push_event():
+    """
+    Detect if any of the pushed commits dealt with a guide and invalidate the
+    cache for those guides.
+    """
+
+    finished = Response(response='', status=200, mimetype='application/json')
+
+    commits = _safe_index_json(request.json, 'commits',
+                               'No commits found in push event')
+    if commits is None:
+        return finished
+
+    ref = _safe_index_json(request.json, 'ref', 'No ref found in push event')
+    if ref is None:
+        return finished
+
+    branch = ref.split('/')[-1]
+
+    for commit in commits:
+        mod_files = _safe_index_json(commit, 'modified',
+                                     'No modified found in push event')
+        if mod_files is None:
+            continue
+
+        for path in _articles(mod_files):
+            app.logger.debug('Invalidating path: "%s", branch: "%s" from push event',
+                             path, branch)
+            cache.delete_file(path, branch)
+
+    return finished
+
+
+def _safe_index_json(json_, key, warning_message):
+    """
+    Safely index the given JSON object 
+
+    :param json_: JSON object
+    :param key: Key to inspect in JSON object
+    :param warning_message: Warning message to log if key is missing
+    :returns: None if not found or value at key
+    """
+
+    try:
+        return json_[key]
+    except KeyError:
+        app.logger.warning('%s, json:%s', warning_message,
+                           json.dumps(request.json))
+        return None
+
+
+def _articles(paths):
+    """
+    Generator through list of articles from a list of paths
+
+    :param paths: List of file paths
+    """
+
+    file_path = u'/%s' % (ARTICLE_FILENAME)
+
+    for path in paths:
+        if path.endswith(file_path):
+            yield path.split(file_path)[0]

--- a/pskb_website/webhooks.py
+++ b/pskb_website/webhooks.py
@@ -5,7 +5,6 @@ Collection of URLs responding to Github webhooks API
 import hmac
 from hashlib import sha1
 import json
-import os
 import re
 from sys import hexversion
 
@@ -31,7 +30,7 @@ def validate_webhook_source():
         - https://github.com/carlos-jenkins/python-github-webhooks/blob/master/webhooks.py
     """
 
-    secret = app.config.get('WEBHOOK_SECRET') 
+    secret = app.config.get('WEBHOOK_SECRET')
     if not secret:
         return
 
@@ -165,7 +164,7 @@ def delete_event():
 
 def _safe_index_json(json_, key, warning_message):
     """
-    Safely index the given JSON object 
+    Safely index the given JSON object
 
     :param json_: JSON object
     :param key: Key to inspect in JSON object


### PR DESCRIPTION
This adds support for the push and delete web hooks.
1. The push event is used to clear our cache for a guide that's modified directly on github.com.  This typically only happens when we merge changes from github.com
2. The delete event is used to delete references to a branch in a guide's metadata.  So, if a branch is deleted via github then the reference to that guide will be removed from the `master` branch.
   - This ultimately leads to the link to a branch being removed from the main guide page on our CMS site.
